### PR TITLE
Support for HTTPS/Port in SetupContext and allow multiple named assertions (without schema)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,25 +57,45 @@ The call chains are structured around 4 main parts.
   .Given()
     //Set up the name for a test suite
     .Name("string")
+
     //Set up Http Header
     //eg: "Accept-Encoding", "gzip, deflate"
     .Header("string", "string")
+
     //Add query string parameters for any HTTP verb
     .Query("string", "string")
+
     //Add parameters for the body of the request if it is POST, PUT or DELETE
     .Param("string", "string")
+
     //Allows for a string content such as JSON or XML.  Used for POST, PUT and DELETE.  The body is overriden if Param() is used
     .Body("string")
+
     //Allows for an object to be serialized to JSON or XML.  Used for POST, PUT and DELETE.  The body is overriden if Param() is used
     .Body<T>(T object)
+
     //Add a file as part of the request.  Doing so will convert the body to a multipart/form request.  Used for POST, PUT and DELETE
     //eg: "file name", "file", "image/jpeg", File.ReadAllBytes("pathtofile")
     .File("string", "string", "string", byte[])
+
     //Set the host of the target server
     //Useful when you want to reuse a test suite between multiple Uris
     .Host("string")
+
     //Set the uri for the target endpoint
     .Uri("string")
+
+    //Sets a different port in the request url
+    //e.g. localhost:5000
+    .Port(int)
+
+    //allows you to use a different http client 
+    //e.g. when you are using testserver
+    .HttpClient("httpClient")
+
+    // sets the default protocol to https instead of http
+    .UseHttps()
+
     //Debug the settings
     .Debug()
 ```
@@ -85,22 +105,27 @@ The call chains are structured around 4 main parts.
   .When()
     //Add a load test to the mix.  Set the # of threads and # of secs to run
     .Load(int, int)
+
     //Use the GET verb with a url.  This will override the above section.
     .Get("string")
     //Use the GET verb without and rely on url settings from Given() section
     .Get()
+
     //Use the POST verb with a url.  This will override the above section.
     .Post("string")
     //Use the POST verb without and rely on the url settings from Given() section.
     .Post()
+
     //Use the PUT verb with a url.  This will override the above section.
     .Put("string")
     //Use the PUT verb without and rely on the url settings from Given() section.
     .Put()
+
     //Use the DELETE verb with a url.  This will override the above section.
     .Delete("string")
     //Use the DELETE verb without and rely on the url settings from Given() section.
     .Delete()
+
     //Debug the settings
     .Debug()
 ```
@@ -112,32 +137,43 @@ The call chains are structured around 4 main parts.
     //The response body is the json blob that is returned from a REST call
     //eg: "test A", x => x.id != null
     .TestBody("string", Func<dynamic, bool>)
+
     //Write a test to make an assertion against the response header
     //eg: "test B", "content-type", x => x.Contains("json")
     .TestHeader("string", "string", Func<string, bool>)
+
     //Write a test to make an assertion against the RTT (elasped round trip time) for the call.
     //eg: "test C", x => x < 1000)
     .TestElaspedTime("string", Func<double, bool>)
+
     //Write a test to make an assertion against load test results.  Refer to the Reference section below for complete list of keys.
     //eg: "test D1", "average-ttl-ms", x => x < 1000 && x > 0
     //eg: "test D2", "total-call", x => x >= 234
     .TestLoad("string", "string", Func<double, bool>)
+
     //Write a test to make an assertion against the response status code
     //eg: "test E", x => x == 200
     .TestStatus("string", Func<int, bool>)
+
     //Assert your test.  Failed test will throw an AssertException
     .Assert("string")
+
     //Apply a v3 or v4 json schema to the response.  Corrupted schemas will throw an ArgumentException
     .Schema("string")
+
     //Assert your schema against the response.  Failed test will throw an AssertException
     .AssertSchema()
+
     //Assert all your test.  Failed test will throw an AssertException
     .AssertAll()
+
     //Output all of the test results
     .WriteAssertions()
+
     //Retrieve a value from the response body
     //eg: x => x.id
     .Retrieve(Func<dynamic, object>)
+    
     //Debug the response
     .Debug()
 ```

--- a/src/RA.Tests/MockResponseContextWithJson.cs
+++ b/src/RA.Tests/MockResponseContextWithJson.cs
@@ -226,5 +226,24 @@ namespace RA.Tests
         {
             _responseWithObject.WriteAssertions();
         }
+
+        [Test]
+        public void AllowMultipleNamedAssertions()
+        {
+            _responseWithObject
+                .TestStatus("first", code => code == 200)
+                .TestBody("second", body => body.id != null)
+                .Assert("first")
+                .Assert("second");
+        }
+
+        [Test]
+        public void AllowMultipleWithoutSchemaAssertion()
+        {
+            _responseWithObject
+                .TestStatus("first", code => code == 200)
+                .TestBody("second", body => body.id != null)
+                .AssertAll();
+        }
     }
 }

--- a/src/RA.Tests/MockResponseContextWithJson.cs
+++ b/src/RA.Tests/MockResponseContextWithJson.cs
@@ -91,6 +91,13 @@ namespace RA.Tests
         }
 
         [Test]
+        public void NoSchemaShouldPass()
+        {
+            _responseWithObject
+                .AssertAll();
+        }
+
+        [Test]
         public void GreaterExecutionTimeShouldPass()
         {
             _responseWithObject
@@ -203,6 +210,7 @@ namespace RA.Tests
         {
             _responseWithObject
                 .Schema(Resource.V3ValidSchema);
+            _responseWithObject.AssertAll();
         }
 
         [Test]
@@ -210,6 +218,7 @@ namespace RA.Tests
         {
             _responseWithObject
                 .Schema(Resource.V4ValidSchema);
+            _responseWithObject.AssertAll();
         }
 
         [Test]

--- a/src/RA.Tests/MockSetupContextWithJson.cs
+++ b/src/RA.Tests/MockSetupContextWithJson.cs
@@ -39,5 +39,36 @@ namespace RA.Tests
             Assert.AreEqual(_setup.Body(),
                 "{\"id\":\"4fc99dd1-9aad-4d63-a247-75c9b72de204\",\"company1\":{\"name\":\"Foo\"},\"company2\":{\"name\":\"f00Baz\"}}");
         }
+
+        [Test]
+        public void UriWithPort()
+        {
+           _setup
+                .Host("localhost")
+                .Port(1500)
+                .Uri("/test");
+
+            var httpContext = _setup.When();
+            httpContext.SetUrl(null);
+
+            Assert.AreEqual("localhost:1500", _setup.Host());
+            Assert.AreEqual("http://localhost:1500/test", httpContext.Url());
+        }
+
+        [Test]
+        public void UrlUsingHttps()
+        {
+            _setup
+                .Host("localhost")
+                .Port(1500)
+                .Uri("/test")
+                .UseHttps();
+
+            var httpContext = _setup.When();
+            httpContext.SetUrl(null);
+
+            Assert.AreEqual("localhost:1500", _setup.Host());
+            Assert.AreEqual("https://localhost:1500/test", httpContext.Url());
+        }
     }
 }

--- a/src/RA/ExecutionContext.cs
+++ b/src/RA/ExecutionContext.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
 using Nito.AsyncEx;
+using RA.Enums;
 using RA.Extensions;
 using RA.Net;
 
@@ -149,7 +150,8 @@ namespace RA
 
         private void AppendHeaders(HttpRequestMessage request)
         {
-            _setupContext.HeaderAccept().ForEach(x => request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(x)));
+            // httpclient default headers must be used because otherwise no value like "application/json;version=1" is allowed.
+            _setupContext.HeaderAccept().ForEach(x => _httpClient.DefaultRequestHeaders.Add(HeaderType.Accept.Value, x));
             _setupContext.HeaderAcceptEncoding().ForEach(x => request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue(x)));
             _setupContext.HeaderAcceptCharset().ForEach(x => request.Headers.AcceptCharset.Add(new StringWithQualityHeaderValue(x)));
             _setupContext.HeaderForEverythingElse().ForEach(x => request.Headers.Add(x.Key, x.Value));

--- a/src/RA/Extensions/GuardExtensions.cs
+++ b/src/RA/Extensions/GuardExtensions.cs
@@ -10,10 +10,11 @@ namespace RA.Extensions
                 throw new Exception(message);
         }
 
-        public static string FixProtocol(this string source)
+        public static string FixProtocol(this string source, bool useHttps)
         {
+            var defaultPortocol = useHttps ? "https" : "http";
             if (!source.StartsWith("http://") && !source.StartsWith("https://"))
-                return "http://" + source;
+                return $"{defaultPortocol}://" + source;
 
             return source;
         }

--- a/src/RA/HttpActionContext.cs
+++ b/src/RA/HttpActionContext.cs
@@ -163,14 +163,14 @@ namespace RA
             return new ExecutionContext(_setupContext, this);
         }
 
-        private void SetUrl(string url)
+        internal void SetUrl(string url)
         {
             if (url.IsEmpty() && _setupContext.Host().IsEmpty())
                 throw new ArgumentException("url must be provided");
 
             var uri = url.IsNotEmpty()
-                ? new Uri(url.FixProtocol())
-                : new Uri(new Uri(_setupContext.Host().FixProtocol()), _setupContext.Uri());
+                ? new Uri(url.FixProtocol(_setupContext.UsesHttps()))
+                : new Uri(new Uri(_setupContext.Host().FixProtocol(_setupContext.UsesHttps())), _setupContext.Uri());
 
             _url = uri.OriginalString;
         }

--- a/src/RA/Properties/AssemblyInfo.cs
+++ b/src/RA/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.1.10.0")]
 [assembly: AssemblyFileVersion("0.1.10.0")]
+[assembly: InternalsVisibleTo("RestAssured.Tests")]

--- a/src/RA/RA.csproj
+++ b/src/RA/RA.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RA</RootNamespace>
     <AssemblyName>RA</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/src/RA/ResponseContext.cs
+++ b/src/RA/ResponseContext.cs
@@ -20,7 +20,7 @@ namespace RA
         private readonly Dictionary<string, double> _loadValues = new Dictionary<string, double>(); 
         private readonly Dictionary<string, bool>  _assertions = new Dictionary<string, bool>();
         private readonly List<LoadResponse> _loadResponses;
-        private bool _isSchemaValid = false;
+        private bool _isSchemaValid = true;
         private List<string> _schemaErrors = new List<string>();
         
 
@@ -175,13 +175,14 @@ namespace RA
             return this;
         }
 
-        public void Assert(string ruleName)
+        public ResponseContext Assert(string ruleName)
         {
-            if (_assertions.ContainsKey(ruleName))
-            {
-                if(!_assertions[ruleName])
-                    throw new AssertException(string.Format("({0}) Test Failed", ruleName));
-            }
+            if (!_assertions.ContainsKey(ruleName)) return this;
+
+            if(!_assertions[ruleName])
+                throw new AssertException($"({ruleName}) Test Failed");
+            // in order to allow multiple asserts
+            return this;
         }
 
         /// <summary>

--- a/src/RA/SetupContext.cs
+++ b/src/RA/SetupContext.cs
@@ -13,9 +13,11 @@ namespace RA
     {
         private string _name;
         private string _host;
+        private int _port;
         private string _uri;
         private string _body;
         private HttpClient _httpClient;
+        private bool _useHttps;
         private Dictionary<string, string> _headers = new Dictionary<string, string>();
         private Dictionary<string, string> _parameters = new Dictionary<string, string>();
         private Dictionary<string, string> _queryStrings = new Dictionary<string, string>();
@@ -67,12 +69,29 @@ namespace RA
         }
 
         /// <summary>
+        /// Sets the port used for the interaction 
+        /// e.g. localhost:1465 
+        /// </summary>
+        /// <param name="port"></param>
+        /// <returns></returns>
+        public SetupContext Port(int port)
+        {
+            _port = port;
+            return this;
+        }
+
+        /// <summary>
         /// Returns the host value.
         /// </summary>
         /// <returns></returns>
         public string Host()
         {
-            return _host;
+            return PortSpecified() ? $"{_host}:{_port}":_host;
+        }
+
+        private bool PortSpecified()
+        {
+            return _port > 0 && _port != 88;
         }
 
         /// <summary>
@@ -290,6 +309,22 @@ namespace RA
             };
             _httpClient = new HttpClient(handler, true);
             return _httpClient;
+        }
+
+        /// <summary>
+        /// Determines that the protocol will be HTTPS insted of HTTP
+        /// e.g. https://...
+        /// </summary>
+        /// <returns></returns>
+        public SetupContext UseHttps()
+        {
+            _useHttps = true;
+            return this;
+        }
+
+        public bool UsesHttps()
+        {
+            return _useHttps;
         }
 
         public HttpActionContext When()


### PR DESCRIPTION
Hi Lam

I added the functionality for having a setup like this
```csharp
    Given()
                .Host("localhost")
                .Port(1500)
                .Uri("/test")
                .UseHttps();
```
and multiple assertions
```csharp
                .TestStatus("first", code => code == 200)
                .TestBody("second", body => body.id != null)
                .Assert("first")
                .Assert("second");
```
please ping me if you have any question.

btw. could you release a new version to nuget.org or could I help you in anyway?