### PR TITLE
Updated for the changes in the fluent code

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,13 +190,13 @@ var endpoint1 = new RestAssured()
     .Uri("/endpoint1");
 
 //Make a copy of the settings from above, but adjust the endpoint.
-var endpoint2 = endpoint1.Clone().Uri("/endpoint2");
+var endpoint2 = endpoint1.Given().Clone().Uri("/endpoint2");
 
 //Do a GET action with the first endpoint configuration
-endpoint1.When().Get().Then().TestBody("test 1", x => x.id != null).Assert("test 1");
+endpoint2.Given().When().Get().Then().TestBody("test 1", x => x.id != null).Assert("test 1");
 
 //Do a POST action with the second endpoint configuration
-endpoint2.When().Post().Then().TestBody("test 1", x => x.id != null).Assert("test 1");
+endpoint2.Given().When().Post().Then().TestBody("test 1", x => x.id != null).Assert("test 1");
 ```
 
 ### Load Test


### PR DESCRIPTION
The endpoints does not expose any other methods than Given(). All the other methods to be used after the Given() which builds up the right chain for consumption. Getting build errors in VS