### PR TITLE
Added support to retrieve a response header and send Form data

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,16 @@ The call chains are structured around 4 main parts.
 
     //Add a file as part of the request.  Doing so will convert the body to a multipart/form request.  Used for POST, PUT and DELETE
     //eg: "file name", "file", "image/jpeg", File.ReadAllBytes("pathtofile")
-    .File("string", "string", "string", byte[])
+    .File("name", "string", "string", "string", byte[])
+
+    // Add the string content to form data as part of the request. It will use the default values of Content-Desposition.
+    .Form("string", "string content")
+
+    // Add the object content to form data as part of the request. Object will be converted into JSON and added to request.
+    .Form("string", object)
+
+    // Add the object content to form data as part of the request. Object will be converted into JSON and added to request. You can explicitly define the content type and desposition.
+    .Form(string name, object content, string contentDispositionName, string contentType)
 
     //Set the host of the target server
     //Useful when you want to reuse a test suite between multiple Uris
@@ -299,6 +308,23 @@ new RestAssured()
         //Third parameter describes the content type that is being added in the byte array
         //Fourth parameter the byte array of content
         .File("fileName", "file", "images/jpeg", File.ReadAllBytes(@"c:\path\to\image"))
+    .When()
+        .Post("http://yourremote.com")
+    .Then()
+        .Debug()
+```
+
+### Using Form
+```C#
+new RestAssured()
+    .Given()
+        .Name("Sending form data")
+        .Param("id", "some identifier")
+        //First parameter is variable name of content being sent in form-data.
+        //Second parameter is the content to be sent. This content will be converted into JSON before being attached to form-data.
+        //Third parameter describes the Content-Desposition
+        //Fourth parameter describes the Content-Type
+        .Form("name", content, "form-data", "multipart/form-data")
     .When()
         .Post("http://yourremote.com")
     .Then()

--- a/src/RA/ExecutionContext.cs
+++ b/src/RA/ExecutionContext.cs
@@ -294,15 +294,29 @@ namespace RA
         {
             // var content = AsyncContext.Run(async () => await result.Response.Content.ReadAsStringAsync());
             var content = result.Response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-
+            var responseHeaders = GetResponseHeaders(result);
             return new ResponseContext(
                 result.Response.StatusCode,
                 content,
-                result.Response.Content.Headers.ToDictionary(x => x.Key.Trim(), x => x.Value),
+                responseHeaders,
                 result.ElaspedExecution,
                 _loadReponses.ToList()
                 );
+        }
 
+        /// <summary>
+        /// Gets the response headers from HTTP response from API.
+        /// </summary>
+        /// <returns>The response headers.</returns>
+        /// <param name="result">Dictionary containing API response headers</param>
+        private Dictionary<string, IEnumerable<string>> GetResponseHeaders(HttpResponseMessageWrapper result)
+        {
+            var responseHeaders = result.Response.Headers.ToDictionary(x => x.Key.Trim(), x => x.Value);
+            foreach (var contentHeader in result.Response.Content.Headers.ToDictionary(x => x.Key.Trim(), x => x.Value))
+            {
+                responseHeaders.Add(contentHeader.Key, contentHeader.Value);
+            }
+            return responseHeaders;
         }
 
         /// <summary>
@@ -313,6 +327,8 @@ namespace RA
         {
             var uri = BuildUri();
 
+            "method".WriteHeader();
+            _httpActionContext.HttpAction().ToString().WriteLine();
             "host".WriteHeader();
             uri.Host.WriteLine();
             "absolute path".WriteHeader();
@@ -327,7 +343,6 @@ namespace RA
             uri.OriginalString.WriteLine();
             "scheme".WriteHeader();
             uri.Scheme.WriteLine();
-
             return this;
         }
     }

--- a/src/RA/ExecutionContext.cs
+++ b/src/RA/ExecutionContext.cs
@@ -186,7 +186,7 @@ namespace RA
 
         private HttpContent BuildContent()
         {
-            if (_setupContext.Files().Any())
+            if (_setupContext.Files().Any() || _setupContext.Forms().Any())
                 return BuildMultipartContent();
             if (_setupContext.Params().Any())
                 return BuildFormContent();
@@ -205,14 +205,24 @@ namespace RA
             _setupContext.Files().ForEach(x =>
             {
                 var fileContent = new ByteArrayContent(x.Content);
-                fileContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment")
+                fileContent.Headers.ContentDisposition = new ContentDispositionHeaderValue(x.ContentDispositionName)
                 {
-                    Name = x.ContentDispositionName.Quote(),
+                    Name = x.Name.Quote(),
                     FileName = x.FileName
                 };
                 fileContent.Headers.ContentType = new MediaTypeHeaderValue(x.ContentType);
-
                 content.Add(fileContent);
+            });
+
+            _setupContext.Forms().ForEach(x =>
+            {
+                var formContent = new StringContent(x.Content);
+                formContent.Headers.ContentDisposition = new ContentDispositionHeaderValue(x.ContentDispositionName)
+                {
+                    Name = x.Name.Quote(),
+                };
+                formContent.Headers.ContentType = new MediaTypeHeaderValue(x.ContentType);
+                content.Add(formContent);
             });
 
             return content;

--- a/src/RA/FormContent.cs
+++ b/src/RA/FormContent.cs
@@ -1,20 +1,18 @@
 namespace RA
 {
-    public class FileContent
+    public class FormContent
     {
-        public FileContent(string name, string fileName, string contentDispositionName, string contentType, byte[] content)
+        public FormContent(string name, string content, string contentDispositionName = "form-data", string contentType = "multipart/form-data")
         {
             Name = name;
-            FileName = fileName;
+            Content = content;
             ContentType = contentType;
             ContentDispositionName = contentDispositionName;
-            Content = content;
         }
 
         public string Name { get; private set; }
-        public string FileName { get; private set; }
+        public string Content { get; private set; }
         public string ContentType { get; private set; }
         public string ContentDispositionName { get; private set; }
-        public byte[] Content { get; private set; }
     }
 }

--- a/src/RA/ResponseContext.cs
+++ b/src/RA/ResponseContext.cs
@@ -8,6 +8,7 @@ using RA.Enums;
 using RA.Exceptions;
 using RA.Extensions;
 using System.Xml.Linq;
+using System.Net.Http;
 
 namespace RA
 {
@@ -34,6 +35,16 @@ namespace RA
             _loadResponses = loadResponses ?? new List<LoadResponse>();
 
             Initialize();
+        }
+
+        /// <summary>
+        /// Retrieve the specified headerName.
+        /// </summary>
+        /// <returns>Header.</returns>
+        /// <param name="headerName">Header name.</param>
+        public string RetrieveHeader(string headerName)
+        {
+            return HeaderValue(headerName);
         }
 
         /// <summary>
@@ -267,7 +278,7 @@ namespace RA
             }
 
             if (!string.IsNullOrEmpty(_content))
-                throw new Exception(string.Format("({0}) not supported", contentType));
+                throw new Exception(string.Format("Content type ({0}) not supported", contentType));
         }
 
         private void ParseLoad()


### PR DESCRIPTION
1 - Be able to retrieve HTTP response header to run the validation.
2 - When reading response headers, ensure to read content headers as well as the response headers.
3 - Be able to send Form Data.