### PR TITLE
Assert response headers

### DIFF
--- a/src/RA.Tests/JsonIpIntegration.cs
+++ b/src/RA.Tests/JsonIpIntegration.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-// using RA.Tests.Data;
 
 namespace RA.Tests
 {
@@ -13,11 +12,11 @@ namespace RA.Tests
                 .Given()
                     .Name("JsonIP")
 				.When()
-                    .Get("http://geoip.nekudo.com/api/")
+                    .Get("https://api.publicapis.org/entries")
                 .Then()
                     .Debug()
-                    .TestBody("ip exist", x => x.ip != null)
-                    .Assert("ip exist");
+                    .TestBody("entries exist", x => x.entries != null)
+                    .Assert("entries exist");
         }
     }
 

--- a/src/RA.Tests/LoadIntegrationTest.cs
+++ b/src/RA.Tests/LoadIntegrationTest.cs
@@ -14,7 +14,7 @@ namespace RA.Tests
                 .When()
                 //one thread for 15 seconds
                     .Load(1, 10)
-                    .Get("http://geoip.nekudo.com/api/")
+                    .Get("https://api.publicapis.org/entries")
                 .Then()
                     .Debug();
         }
@@ -28,7 +28,7 @@ namespace RA.Tests
                 .When()
                 //one thread for 15 seconds
                     .Load(6, 10)
-                    .Get("http://geoip.nekudo.com/api/")
+                    .Get("https://api.publicapis.org/entries")
                 .Then()
                     .Debug();
         }

--- a/src/RA.Tests/MockResponseContextWithJson.cs
+++ b/src/RA.Tests/MockResponseContextWithJson.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Net;
 using NUnit.Framework;
 using RA.Exceptions;
-// using RA.Tests.Data;
 
 namespace RA.Tests
 {

--- a/src/RA.Tests/MockResponseContextWithJson.cs
+++ b/src/RA.Tests/MockResponseContextWithJson.cs
@@ -32,23 +32,21 @@ namespace RA.Tests
                 "{\"key\":\"AK\", \"value\":\"Alaska\"}" +
                 "]";
 
-            var header = new Dictionary<string, IEnumerable<string>>
+            var headers = new Dictionary<string, IEnumerable<string>>
             {
-                {
-                    "Content-Type",
-                    new List<string> {"application/json"}
-                }
+                {"Content-Type", new List<string> {"application/json"}},
+                {"Date", new List<string> {"Fri, 02 Jul 2021 10:29:50 GMT"}}
             };
 
             var emptyHeader = new Dictionary<string, IEnumerable<string>>();
 
 
             var loadResults = new List<LoadResponse> {new LoadResponse(200, 78978078)};
-            _responseWithObject = new ResponseContext(HttpStatusCode.OK, responseObjectContent, header,
+            _responseWithObject = new ResponseContext(HttpStatusCode.OK, responseObjectContent, headers,
                 _mockElapsedTimespan, loadResults);
-            _responseWithObject2 = new ResponseContext(HttpStatusCode.OK, responseObjectContent, header,
+            _responseWithObject2 = new ResponseContext(HttpStatusCode.OK, responseObjectContent, headers,
                 _mockElapsedTimespan, loadResults);
-            _responseWithArray = new ResponseContext(HttpStatusCode.OK, responseArrayContent, header,
+            _responseWithArray = new ResponseContext(HttpStatusCode.OK, responseArrayContent, headers,
                 _mockElapsedTimespan, loadResults);
             _responseWithNothing = new ResponseContext(HttpStatusCode.OK, "", emptyHeader, _mockElapsedTimespan,
                 loadResults);
@@ -163,6 +161,22 @@ namespace RA.Tests
             _responseWithObject
                 .TestHeader("content header has app/json upper", "CONTENT-TYPE", x => x == "application/json")
                 .Assert("content header has app/json upper");
+        }
+
+        [Test]
+        public void TestHeaderWithDateUpperCased()
+        {
+            _responseWithObject
+                .TestHeader("content header has DATE upper", "DATE", x => x == "Fri, 02 Jul 2021 10:29:50 GMT")
+                .Assert("content header has date upper");
+        }
+
+        [Test]
+        public void TestHeaderWithDateLowerCased()
+        {
+            _responseWithObject
+                .TestHeader("content header has date upper", "date", x => x == "Fri, 02 Jul 2021 10:29:50 GMT")
+                .Assert("content header has date upper");
         }
 
         [Test]

--- a/src/RA/ExecutionContext.cs
+++ b/src/RA/ExecutionContext.cs
@@ -292,17 +292,29 @@ namespace RA
 
         private ResponseContext BuildFromResponse(HttpResponseMessageWrapper result)
         {
-            // var content = AsyncContext.Run(async () => await result.Response.Content.ReadAsStringAsync());
             var content = result.Response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            var headers = GetHeaders(result);
 
             return new ResponseContext(
                 result.Response.StatusCode,
                 content,
-                result.Response.Content.Headers.ToDictionary(x => x.Key.Trim(), x => x.Value),
+                headers,
                 result.ElaspedExecution,
-                _loadReponses.ToList()
-                );
+                _loadReponses.ToList());
+        }
 
+        private static Dictionary<string, IEnumerable<string>> GetHeaders(HttpResponseMessageWrapper result)
+        {
+            var headers = result.Response.Headers.ToDictionary(x => x.Key.Trim(), x => x.Value);
+            var contentHeaders = result.Response.Content.Headers.ToDictionary(x => x.Key.Trim(), x => x.Value);
+
+            foreach (var contentHeader in contentHeaders)
+            {
+                if(!headers.ContainsKey(contentHeader.Key))
+                    headers.Add(contentHeader.Key, contentHeader.Value);
+            }
+
+            return headers;
         }
 
         /// <summary>

--- a/src/RA/ExecutionContext.cs
+++ b/src/RA/ExecutionContext.cs
@@ -21,7 +21,7 @@ namespace RA
         private readonly SetupContext _setupContext;
         private readonly HttpActionContext _httpActionContext;
         private readonly HttpClient _httpClient;
-        private ConcurrentQueue<LoadResponse> _loadReponses = new ConcurrentQueue<LoadResponse>();
+        private ConcurrentQueue<LoadResponse> _loadResponses = new ConcurrentQueue<LoadResponse>();
 
         public ExecutionContext(SetupContext setupContext, HttpActionContext httpActionContext)
         {
@@ -272,7 +272,7 @@ namespace RA
         public async Task MapCall()
         {
             var loadResponse = new LoadResponse(-1, -1);
-            _loadReponses.Enqueue(loadResponse);
+            _loadResponses.Enqueue(loadResponse);
 
             var result = await ExecuteCall();
             loadResponse.StatusCode = (int)result.Response.StatusCode;
@@ -300,7 +300,7 @@ namespace RA
                 content,
                 headers,
                 result.ElaspedExecution,
-                _loadReponses.ToList());
+                _loadResponses.ToList());
         }
 
         private static Dictionary<string, IEnumerable<string>> GetHeaders(HttpResponseMessageWrapper result)


### PR DESCRIPTION
https://github.com/lamchakchan/RestAssured.Net/blob/764c883744ce2b2893a425c72357a0b4b9898e16/src/RA/ResponseContext.cs#L72-L82
`TestHeader` method states that `Setup a test against response headers.`, however, the assert is not being done against `Response.Headers`, but `Response.Content.Headers`: 
https://github.com/lamchakchan/RestAssured.Net/blob/764c883744ce2b2893a425c72357a0b4b9898e16/src/RA/ExecutionContext.cs#L293-L306
As far as I know, currently there is no possibility to assert `Response.Headers`. So this PR fixes this issue.